### PR TITLE
keyspace and table names in NodeInfo must be in lowercase.

### DIFF
--- a/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
+++ b/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
@@ -385,8 +385,8 @@ public class JmxScraper {
                 Set<ObjectName> names = beanConn.queryNames(ObjectName.getInstance("org.apache.cassandra.db:type=ColumnFamilies,keyspace=*,columnfamily=*"), null);
                 for (ObjectName name : names) {
                     String[] values = name.toString().split("[=,]");
-                    keyspaces.add(values[3]);
-                    tables.add(values[5]);
+                    keyspaces.add(values[3].toLowerCase());
+                    tables.add(values[5].toLowerCase());
                 }
             } catch (Exception e) {
                 logger.error("Cannot retrieve keyspaces/tables information", e);


### PR DESCRIPTION
In the `JmxScraper.java` inside method `getMetricPath()` properties is transformed to lowercase.

```java
    private String getMetricPath(ObjectName mbeanName, MBeanAttributeInfo attr) {
        String properties = PATTERN.matcher(mbeanName.toString())
                .replaceAll(metricSeparator)
                .replace(' ', '_') + metricSeparator + attr.getName();
        return properties.toLowerCase();  <====
    }
```

It's work great with the cql tables because when you create table using `CREATE TABLE <tablename>` statement, cassandra lowercase `<tablename>`.

Statements below are same:
```cqlsh
CREATE TABLE test.NAME ( id UUID PRIMARY KEY, lastname text);
CREATE TABLE test.Name ( id UUID PRIMARY KEY, lastname text);
CREATE TABLE test.nAmE ( id UUID PRIMARY KEY, lastname text);
```
Everything work fine. But, if you have tables created using cassandra-cli, their names isn't lowercased inside cassandra.

Condition 
```java
if (nodeInfo.keyspaces.contains(keyspaceName) && nodeInfo.tables.contains(tableName)) { <==
    STATS.labels(nodeInfo.clusterName, nodeInfo.datacenterName, keyspaceName, tableName, metricName).set(value);
    return;
}
```
not `true` and label `table` is not set.