### PR TITLE
Add metric pendingtasksbytablename to exporter

### DIFF
--- a/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
+++ b/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
@@ -142,6 +142,21 @@ public class JmxScraper {
             }
         }
 
+
+        if (metricName.startsWith("org:apache:cassandra:metrics:compaction:pendingtasksbytablename:")) {
+            int pathLength = "org:apache:cassandra:metrics:compaction:pendingtasksbytablename:".length();
+            int keyspacePos = metricName.indexOf(':', pathLength);
+            int tablePos = metricName.indexOf(':', keyspacePos + 1);
+            String keyspaceName = metricName.substring(pathLength, keyspacePos);
+            String tableName = tablePos > 0 ? metricName.substring(keyspacePos + 1, tablePos) : "";
+
+            if (nodeInfo.keyspaces.contains(keyspaceName) && nodeInfo.tables.contains(tableName)) {
+                this.stats.labels(concat(new String[] {nodeInfo.clusterName, nodeInfo.datacenterName, keyspaceName, tableName, metricName}, additionalLabelValues)).set(value);
+                return;
+            }
+        }
+
+
         this.stats.labels(concat( new String[] { nodeInfo.clusterName, nodeInfo.datacenterName, "", "", metricName}, additionalLabelValues)).set(value);
     }
 
@@ -300,6 +315,17 @@ public class JmxScraper {
 
                     // https://books.google.fr/books?id=BvsVuph6ehMC&pg=PA82
                     // EstimatedHistogram are object for JMX but are long[] behind
+                } else if (first == '{' || mBeanInfo.metricName == "org:apache:cassandra:metrics:compaction:pendingtasksbytablename:value") {
+                    HashMap<String, HashMap<String, Integer>> pendingTasks = (HashMap<String, HashMap<String, Integer>>) value;
+                    for (String keyspace : pendingTasks.keySet()) {
+                        for (String table : pendingTasks.get(keyspace).keySet()) {
+                            String labels = String.join(":", keyspace, table, "value");
+                            String metricName = mBeanInfo.metricName.replace("value", labels);
+                            updateStats(nodeInfo, metricName, pendingTasks.get(keyspace).get(table).doubleValue());
+                        }
+                    }
+
+
                 } else if (str.startsWith(long[].class.getName())) {
 
                     // This is ugly to redo the shouldScrap and metricName formating this late

--- a/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
+++ b/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
@@ -312,10 +312,8 @@ public class JmxScraper {
                 //Most beans declared as Object are Double in disguise
                 if (first >= '0' && first <= '9') {
                     updateStats(nodeInfo, mBeanInfo.metricName, Double.valueOf(str));
-
-                    // https://books.google.fr/books?id=BvsVuph6ehMC&pg=PA82
-                    // EstimatedHistogram are object for JMX but are long[] behind
-                } else if (first == '{' || mBeanInfo.metricName == "org:apache:cassandra:metrics:compaction:pendingtasksbytablename:value") {
+                    
+                } else if (first == '{' && mBeanInfo.metricName.equalsIgnoreCase("org:apache:cassandra:metrics:compaction:pendingtasksbytablename:value")) {
                     HashMap<String, HashMap<String, Integer>> pendingTasks = (HashMap<String, HashMap<String, Integer>>) value;
                     for (String keyspace : pendingTasks.keySet()) {
                         for (String table : pendingTasks.get(keyspace).keySet()) {
@@ -325,7 +323,8 @@ public class JmxScraper {
                         }
                     }
 
-
+                    // https://books.google.fr/books?id=BvsVuph6ehMC&pg=PA82
+                    // EstimatedHistogram are object for JMX but are long[] behind
                 } else if (str.startsWith(long[].class.getName())) {
 
                     // This is ugly to redo the shouldScrap and metricName formating this late


### PR DESCRIPTION
Expose `org.aparche.cassandra.metrics.compaction.pendingtasksbytablename` on the exporter.

Related to #65 