### PR TITLE
Bump jackson dependencies to current versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     compile  group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
 
     // YAML parser
-    compile  group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.8.9'
-    compile  group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.8.8'
+    compile  group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.10.2'
+    compile  group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.10.2'
 
     // Prometheus
     compile group: 'io.prometheus', name: 'simpleclient', version: '0.6.0'


### PR DESCRIPTION
There are a bunch of vulnerabilities in `com.fasterxml.jackson.core_jackson-databind` version 2.8.9.
This bumps to the current releases and seems to require no code changes to build.

It would be great if you could merge and release a new docker image version built against a fresh `openjdk` base container, since that also has accumulated a bunch of CVEs (although changing to `:11-slim-buster` rather than `-sid` might be advisable at this point).