### PR TITLE
Give read permissions to non-root

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,6 @@ RUN echo "${EXPORTER_SHA512}  /opt/cassandra_exporter/cassandra_exporter.jar" > 
 ADD config.yml /etc/cassandra_exporter/
 ADD run.sh /
 
-RUN chmod +x /sbin/dumb-init && chmod g+wrx -R /opt/cassandra_exporter && chmod g+wrx -R /etc/cassandra_exporter
+RUN chmod +x /sbin/dumb-init && chmod g+wrX,o+rX -R /opt/cassandra_exporter && chmod g+wrX,o+rX -R /etc/cassandra_exporter
 
 CMD ["/sbin/dumb-init", "/bin/bash", "/run.sh"]


### PR DESCRIPTION
Without this it's hard to run the exporter as non-root.
Also, there is no need to give the executable bit to regular files, the capital `X` should be enough.