### PR TITLE
Add basic support for Lists

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -50,6 +50,9 @@ blacklist:
    # Should we export metrics for system keyspaces/tables ?
    - org:apache:cassandra:metrics:[^:]+:system[^:]*:.*
 
+   # Logback doesn't have any useful metrics
+   - ch:qos:logback:.*
+
    # Don't scrap us
    - com:criteo:nosql:cassandra:exporter:.*
 

--- a/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
+++ b/src/main/java/com/criteo/nosql/cassandra/exporter/JmxScraper.java
@@ -291,6 +291,10 @@ public class JmxScraper {
                 updateStats(nodeInfo, mBeanInfo.metricName, ((Boolean) value) ? 1.0 : 0.0);
                 break;
 
+            case "java.util.List":
+                updateStats(nodeInfo, mBeanInfo.metricName, Double.valueOf(((List) value).size()));
+                break;
+
             case "javax.management.openmbean.CompositeData":
                 CompositeData data = ((CompositeData) value);
                 CompositeType types = ((CompositeData) value).getCompositeType();


### PR DESCRIPTION
I am primarily interested in the following metrics for #79:

- `org:apache:cassandra:db:storageservice:livenodes`
- `org:apache:cassandra:db:storageservice:unreachablenodes`

With default `config.yml` it adds only 2 new metrics for me (but they are doesn't have any sense):

```
cassandra_stats{cluster="test",datacenter="test1",keyspace="",table="",name="ch:qos:logback:classic:name=default:ch:qos:logback:classic:jmx:jmxconfigurator:statuses",} 14.0
cassandra_stats{cluster="test",datacenter="test1",keyspace="",table="",name="ch:qos:logback:classic:name=default:ch:qos:logback:classic:jmx:jmxconfigurator:loggerlist",} 266.0
```

Please feel free to close PR If you have a better idea how to solve #79 or it is just unacceptable way. :)