### PR TITLE
Change listen address and port variable

### DIFF
--- a/ansible/roles/ansible-cassandra-exporter/defaults/main.yml
+++ b/ansible/roles/ansible-cassandra-exporter/defaults/main.yml
@@ -2,8 +2,8 @@
 
 cassandra_exporter_version: 2.2.0
 
-cassandra_listen_address: "0.0.0.0"
-cassandra_listen_port: "8080"
+cassandra_exporter_listen_address: "0.0.0.0"
+cassandra_exporter_listen_port: "8080"
 cassandra_exporter_binary_url: 'https://github.com/criteo/cassandra_exporter/releases/download/{{cassandra_exporter_version}}/cassandra_exporter-{{cassandra_exporter_version}}-all.jar'
 cassandra_exporter_config_url: 'https://raw.githubusercontent.com/criteo/cassandra_exporter/master/config.yml'
 

--- a/ansible/roles/ansible-cassandra-exporter/tasks/main.yml
+++ b/ansible/roles/ansible-cassandra-exporter/tasks/main.yml
@@ -51,7 +51,7 @@
   lineinfile:
     regexp: "^listenAddress"
     dest:  "{{ cassandra_exporter_config_dir }}/config.yml"
-    line: "listenAddress: {{ cassandra_listen_address }}"
+    line: "listenAddress: {{ cassandra_exporter_listen_address }}"
   notify:
     - restart cassandra exporter
 
@@ -59,7 +59,7 @@
   lineinfile:
     regexp: "^listenPort"
     dest:  "{{ cassandra_exporter_config_dir }}/config.yml"
-    line: "listenPort: {{ cassandra_listen_port }}"
+    line: "listenPort: {{ cassandra_exporter_listen_port }}"
   notify:
     - restart cassandra exporter
 


### PR DESCRIPTION
Listen address and port should follow the same naming convention as `cassandra_exporter_` as `cassandra_listen` can be cassandra configuration variable