### PR TITLE
Sed config file in /tmp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ You can pull an image directly from [Dockerhub](https://hub.docker.com/r/criteor
 docker pull criteord/cassandra_exporter:latest
 ```
 
+Run docker in read-only mode (/tmp must be mounted as tmpfs to authorize sed on the config.yml when using dedicated env variables)
+```
+docker run -e CASSANDRA_EXPORTER_CONFIG_host=localhost:7198 --read-only --tmpfs=/tmp criteord/cassandra_exporter:latest
+```
+
 ## Kubernetes
 
 To get an idea on how to integrate Cassandra Exporter in Kubernetes, you can look at [this helm Chart](https://github.com/MySocialApp/kubernetes-helm-chart-cassandra).

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -11,21 +11,22 @@ export JVM_OPTS="${JVM_OPTS}" # i.e -Xmx1024m
 
 echo "Starting Cassandra exporter"
 echo "JVM_OPTS: $JVM_OPTS"
+cp /etc/cassandra_exporter/config.yml /tmp/config.yml
 while IFS='=' read -r name value ; do
   if [[ $name == 'CASSANDRA_EXPORTER_CONFIG_'* ]]; then
     val="${!name}"
     echo "$name $val"
     field=$(echo $name | sed -r 's/CASSANDRA_EXPORTER_CONFIG_(.+)/\1/')
-    sed -ri "s/^($field):.*/\1: $val/" "/etc/cassandra_exporter/config.yml"
+    sed -ri "s/^($field):.*/\1: $val/" "/tmp/config.yml"
   fi
 done < <(env)
 
-host=$(grep -m1 'host:' /etc/cassandra_exporter/config.yml | cut -d ':' -f2)
-port=$(grep -m1 'host:' /etc/cassandra_exporter/config.yml | cut -d ':' -f3)
+host=$(grep -m1 'host:' /tmp/config.yml | cut -d ':' -f2)
+port=$(grep -m1 'host:' /tmp/config.yml | cut -d ':' -f3)
 
 while ! nc -z $host $port; do
   echo "Waiting for Cassandra JMX to start on $host:$port"
   sleep 1
 done
 
-/sbin/dumb-init java ${JVM_OPTS} -jar /opt/cassandra_exporter/cassandra_exporter.jar /etc/cassandra_exporter/config.yml
+/sbin/dumb-init java ${JVM_OPTS} -jar /opt/cassandra_exporter/cassandra_exporter.jar /tmp/config.yml


### PR DESCRIPTION
If running container with read-only option it is not possible to edit (sed) the config
file in /etc/cassandra_exporter
When running read-only container it is possible to provide a tmpfs path where write will be allowed
For ex.:  docker run -e CASSANDRA_EXPORTER_CONFIG_host=localhost:7198 --read-only --tmpfs=/tmp criteord/cassandra_exporter:latest
So copy file in /tmp and sed from that folder

Close #100 