### PR TITLE
fix: Docker image to use eclipse-temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 1.§§
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: '11'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.§§
+    - name: Set up JDK 1.11
       uses: actions/setup-java@v3
       with:
         distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: '11'
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,20 @@
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-jammy
 
 ARG EXPORTER_VERSION=2.3.8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		netcat \
+        dumb-init \
+        netcat \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/cassandra_exporter /opt/cassandra_exporter
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 /sbin/dumb-init
 ADD https://github.com/criteo/cassandra_exporter/releases/download/${EXPORTER_VERSION}/cassandra_exporter-${EXPORTER_VERSION}.jar /opt/cassandra_exporter/cassandra_exporter.jar
 ADD config.yml /etc/cassandra_exporter/
 ADD docker/run.sh /
 
-RUN chmod +x /sbin/dumb-init && chmod g+wrX,o+rX -R /opt/cassandra_exporter && chmod g+wrX,o+rX -R /etc/cassandra_exporter
+RUN chmod g+wrX,o+rX -R /opt/cassandra_exporter \
+ && chmod g+wrX,o+rX -R /etc/cassandra_exporter
 
-CMD ["/sbin/dumb-init", "/bin/bash", "/run.sh"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["bash", "/run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -24,7 +24,7 @@ done < <(env)
 host=$(grep -m1 'host:' /tmp/config.yml | cut -d ':' -f2)
 port=$(grep -m1 'host:' /tmp/config.yml | cut -d ':' -f3)
 
-while ! nc -z $host $port; do
+while ! nc -z "$host" "$port"; do
   echo "Waiting for Cassandra JMX to start on $host:$port"
   sleep 1
 done


### PR DESCRIPTION
As the OpenJDK is a mystery meat even if the Docker image is actually built on the abandoned AdoptOpenJDK project.